### PR TITLE
[gh-migrate] run astgrep rules/actions-breaking-change/ubuntu-latest-250117.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CICD
 on: [push]
 jobs:
   cicd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
This PR is created by [gh-migrate](https://github.com/HikaruEgashira/gh-migrate)
---
```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
id: ubuntu-latest-250117
language: yml
rule: {pattern: "runs-on: ubuntu-latest"}
fix: "runs-on: ubuntu-24.04"
message: "Ubuntu-latest upcoming breaking changes"
files:
  - '**/.github/workflows/**'

```